### PR TITLE
Exclude `manage.py` from coverage counting

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# pragma: no cover
 
 from config import Config
 


### PR DESCRIPTION
For it's useless to track
