### PR TITLE
Use the pip install version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,4 @@ test:
   override:
     - coverage run --source='.' -m behave
   post:
-    - bash <(curl -s https://codecov.io/bash)
+    - pip install codecov && codecov


### PR DESCRIPTION
Looks like the official documentation suggests this way.

https://github.com/codecov/example-python
